### PR TITLE
Use OpenSwiftUI trait condition directly

### DIFF
--- a/Example/SwiftUIExample/ContentView.swift
+++ b/Example/SwiftUIExample/ContentView.swift
@@ -29,17 +29,19 @@ struct ContentView: View {
     }
 }
 
-#if os(iOS) || os(tvOS) || os(visionOS)
+#if canImport(UIKit)
+import UIKit
 typealias PlatformColor = UIColor
-#elseif os(macOS)
+#elseif canImport(AppKit)
+import AppKit
 typealias PlatformColor = NSColor
 #endif
 
 private extension Color {
     init(platformColor: PlatformColor) {
-        #if os(iOS) || os(tvOS) || os(visionOS)
+        #if canImport(UIKit)
         self.init(uiColor: platformColor)
-        #elseif os(macOS)
+        #elseif canImport(AppKit)
         self.init(nsColor: platformColor)
         #endif
     }

--- a/Example/Tuist/Package.swift
+++ b/Example/Tuist/Package.swift
@@ -9,7 +9,8 @@ import struct ProjectDescription.Settings
 let packageSettings = PackageSettings(
     targetSettings: [
         "ScreenShieldKit": Settings.settings(base: [
-            "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "$(inherited) OPENSWIFTUI",
+            // TODO: Xcode does not support enable trait yet
+            "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "$(inherited) OpenSwiftUI",
         ]),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -35,9 +35,6 @@ let package = Package(
                     package: "OpenSwiftUI-spm",
                     condition: .when(traits: ["OpenSwiftUI"])
                 ),
-            ],
-            swiftSettings: [
-                .define("OPENSWIFTUI", .when(traits: ["OpenSwiftUI"])),
             ]
         ),
     ]

--- a/Sources/ScreenShieldKit/OpenSwiftUI+ScreenShieldKit.swift
+++ b/Sources/ScreenShieldKit/OpenSwiftUI+ScreenShieldKit.swift
@@ -5,7 +5,7 @@
 //  Copyright (c) 2025-2026 Kyle-Ye
 //  SPDX-License-Identifier: MIT
 
-#if OPENSWIFTUI && canImport(OpenSwiftUI)
+#if OpenSwiftUI && canImport(OpenSwiftUI)
 import OpenSwiftUI
 
 @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)


### PR DESCRIPTION
## Summary

- Use the SwiftPM trait condition directly instead of mirroring it through a separate `OPENSWIFTUI` compile definition.
- Updates the Tuist example settings to use the same condition while Xcode lacks package trait support.
- Make the SwiftUI example platform-color checks use framework availability via `canImport(UIKit)` and `canImport(AppKit)`.

Validation:
- `swift test` built the package successfully, then exited with SwiftPM's `no tests found` message because the package has no `Tests` target.
- `swift build --traits OpenSwiftUI` passed.
