### PR TITLE
Add LookInsideServer to examples

### DIFF
--- a/Example/Project.swift
+++ b/Example/Project.swift
@@ -7,6 +7,24 @@ let baseSettings: SettingsDictionary = [
     "DEVELOPMENT_TEAM": "VB7MJ8R223",
 ]
 
+let lookInsideServerDependencies: [TargetDependency] = [
+    .external(name: "LookInsideServer", condition: .when([.ios, .macos])),
+]
+
+let lookInsideServerReleaseExclusionSettings: SettingsDictionary = [
+    "EXCLUDED_SOURCE_FILE_NAMES": "$(inherited) LookInsideServer*",
+]
+
+func appSettings(base: SettingsDictionary = baseSettings) -> Settings {
+    .settings(
+        base: base,
+        configurations: [
+            .debug(name: "Debug"),
+            .release(name: "Release", settings: lookInsideServerReleaseExclusionSettings),
+        ]
+    )
+}
+
 let appInfoPlist: [String: Plist.Value] = [
     "CFBundleDevelopmentRegion": "$(DEVELOPMENT_LANGUAGE)",
     "CFBundleExecutable": "$(EXECUTABLE_NAME)",
@@ -75,8 +93,8 @@ let project = Project(
             sources: ["UIKitExample/**"],
             dependencies: [
                 .external(name: "ScreenShieldKit"),
-            ],
-            settings: .settings(base: baseSettings)
+            ] + lookInsideServerDependencies,
+            settings: appSettings()
         ),
         .target(
             name: "UIKitExampleTests",
@@ -135,8 +153,8 @@ let project = Project(
             sources: ["AppKitExample/**"],
             dependencies: [
                 .external(name: "ScreenShieldKit"),
-            ],
-            settings: .settings(base: baseSettings)
+            ] + lookInsideServerDependencies,
+            settings: appSettings()
         ),
         .target(
             name: "SwiftUIExample",
@@ -151,8 +169,8 @@ let project = Project(
             sources: ["SwiftUIExample/**"],
             dependencies: [
                 .external(name: "ScreenShieldKit"),
-            ],
-            settings: .settings(base: baseSettings)
+            ] + lookInsideServerDependencies,
+            settings: appSettings()
         ),
         .target(
             name: "SwiftUIExampleUITests",
@@ -184,8 +202,8 @@ let project = Project(
             dependencies: [
                 .external(name: "OpenSwiftUI"),
                 .external(name: "ScreenShieldKit"),
-            ],
-            settings: .settings(base: baseSettings)
+            ] + lookInsideServerDependencies,
+            settings: appSettings()
         ),
         .target(
             name: "OpenSwiftUIExampleUITests",

--- a/Example/README.md
+++ b/Example/README.md
@@ -1,0 +1,31 @@
+# ScreenShieldKit Example
+
+## Generate Project
+
+The recommended setup path is the local setup script:
+
+```shell
+./setup.sh
+```
+
+The script trusts and installs the tools declared by `Example/mise.toml`, then runs Tuist through `mise exec` so the pinned Tuist version is used.
+
+To run the steps manually:
+
+```shell
+mise trust mise.toml
+mise install
+mise exec -- tuist install
+mise exec -- tuist generate --no-open
+```
+
+## LookInsideServer
+
+The generated Debug example app targets include LookInsideServer for UI inspection on iOS and macOS. Release configurations exclude the LookInsideServer sources with `EXCLUDED_SOURCE_FILE_NAMES`, so release builds do not include the inspector server.
+
+## Schemes
+
+- `UIKitExample`: UIKit demo and the target app for UI tests.
+- `AppKitExample`: macOS AppKit demo.
+- `SwiftUIExample`: SwiftUI demo for iOS and macOS.
+- `OpenSwiftUIExample`: OpenSwiftUI demo for iOS and macOS.

--- a/Example/Tuist/Package.resolved
+++ b/Example/Tuist/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "701508ffcb3f7857d75806993fd1b6f47576cd5a40ab62bad795775510ec5573",
+  "originHash" : "21a481b647218c4a8b7b1fe593232909a0f0a8a0eb07e8ed2a6d991517db7ea6",
   "pins" : [
+    {
+      "identity" : "lookinside-release",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/LookInsideApp/LookInside-Release.git",
+      "state" : {
+        "revision" : "7514cfa8bd24a78f74d8b982c429e7d61ef58134",
+        "version" : "0.2.2"
+      }
+    },
     {
       "identity" : "openswiftui-spm",
       "kind" : "remoteSourceControl",

--- a/Example/Tuist/Package.swift
+++ b/Example/Tuist/Package.swift
@@ -3,10 +3,15 @@
 import PackageDescription
 
 #if TUIST
-import struct ProjectDescription.PackageSettings
-import struct ProjectDescription.Settings
+import ProjectDescription
 
 let packageSettings = PackageSettings(
+    productTypes: [
+        "LookInsideServer": .framework,
+    ],
+    productDestinations: [
+        "LookInsideServer": [.iPhone, .iPad, .mac],
+    ],
     targetSettings: [
         "ScreenShieldKit": Settings.settings(base: [
             // TODO: Xcode does not support enable trait yet
@@ -16,7 +21,7 @@ let packageSettings = PackageSettings(
 )
 #endif
 
-let package = Package(
+let package = PackageDescription.Package(
     name: "ScreenShieldKitExamplesDependencies",
     dependencies: [
         .package(
@@ -25,5 +30,6 @@ let package = Package(
                 .trait(name: "OpenSwiftUI"),
             ]
         ),
+        .package(url: "https://github.com/LookInsideApp/LookInside-Release.git", from: "0.2.2"),
     ]
 )

--- a/Example/setup.sh
+++ b/Example/setup.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+
+cd "$SCRIPT_DIR"
+mise trust "$SCRIPT_DIR/mise.toml"
+mise install
+mise exec -- tuist install
+mise exec -- tuist generate --no-open


### PR DESCRIPTION
## Agent Summary

Adds a local Example setup path and documents how to generate the Tuist project with the pinned toolchain.

The Example Tuist package now includes LookInsideServer from LookInside-Release 0.2.2 and configures it as a framework product for iOS and macOS. The app targets link it in Debug builds, while Release configurations exclude LookInsideServer sources with `EXCLUDED_SOURCE_FILE_NAMES` so inspector code is not included in release builds.

Validation performed:

- `./setup.sh`
- `mise exec -- tuist generate --no-open`
- `xcodebuild -list -workspace ScreenShieldKitExamples.xcworkspace`