### PR TITLE
Add SPI interface build support

### DIFF
--- a/.github/actions/package/action.yml
+++ b/.github/actions/package/action.yml
@@ -1,0 +1,36 @@
+name: Run Package Tests
+description: Set up Xcode and run the package test coverage.
+
+inputs:
+  xcode-version:
+    description: The Xcode version to select with setup-xcode.
+    required: true
+  xcode-name:
+    description: The Xcode app bundle name under /Applications.
+    required: true
+  destination:
+    description: The xcodebuild destination value for package UI-hosted tests.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Select Xcode
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: ${{ inputs.xcode-version }}
+
+    - name: Prepare Xcode
+      shell: bash
+      run: |
+        sudo xcode-select -s "/Applications/${{ inputs.xcode-name }}/Contents/Developer"
+        swift --version
+
+    - name: Run OpenSwiftUI trait unit tests
+      uses: ./.github/actions/example
+      with:
+        scheme: ScreenShieldKitPackageTests
+        platform: ios
+        xcode-version: ${{ inputs.xcode-version }}
+        xcode-name: ${{ inputs.xcode-name }}
+        destination: ${{ inputs.destination }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -22,20 +22,20 @@ on:
 
 jobs:
   test:
-    name: ${{ matrix.config.name }}
-    runs-on: ${{ matrix.config.runs_on }}
+    name: xcodebuild / iOS ${{ matrix.runtime.ios_version }} / Xcode ${{ matrix.runtime.xcode_version }} / ${{ matrix.runtime.runs_on }}
+    runs-on: ${{ matrix.runtime.runs_on }}
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
     strategy:
       fail-fast: false
       matrix:
-        config:
-          - name: 'SwiftPM / Xcode 16.4 on macOS 15'
-            runs_on: macos-15
+        runtime:
+          - runs_on: macos-15
             xcode_version: '16.4'
             xcode_name: 'Xcode_16.4.app'
             ios_version: '18.5'
             device: 'iPhone 16 Pro'
-          - name: 'SwiftPM / Xcode 26.3 on macOS 26'
-            runs_on: macos-26
+          - runs_on: macos-26
             xcode_version: '26.3'
             xcode_name: 'Xcode_26.3.app'
             ios_version: '26.2'
@@ -46,6 +46,6 @@ jobs:
       - name: Run package tests
         uses: ./.github/actions/package
         with:
-          xcode-version: ${{ matrix.config.xcode_version }}
-          xcode-name: ${{ matrix.config.xcode_name }}
-          destination: 'platform=iOS Simulator,name=${{ matrix.config.device }},OS=${{ matrix.config.ios_version }}'
+          xcode-version: ${{ matrix.runtime.xcode_version }}
+          xcode-name: ${{ matrix.runtime.xcode_name }}
+          destination: 'platform=iOS Simulator,name=${{ matrix.runtime.device }},OS=${{ matrix.runtime.ios_version }}'

--- a/.github/workflows/package_interface.yml
+++ b/.github/workflows/package_interface.yml
@@ -24,22 +24,21 @@ on:
 
 jobs:
   test:
-    name: ${{ matrix.config.name }}
-    runs-on: ${{ matrix.config.runs_on }}
+    name: xcodebuild / iOS ${{ matrix.runtime.ios_version }} / Xcode ${{ matrix.runtime.xcode_version }} / ${{ matrix.runtime.runs_on }}
+    runs-on: ${{ matrix.runtime.runs_on }}
     env:
+      GITHUB_TOKEN: ${{ github.token }}
       SCREENSHIELDKIT_USE_SPI_INTERFACES: '1'
     strategy:
       fail-fast: false
       matrix:
-        config:
-          - name: 'SwiftPM SPI Interfaces / Xcode 16.4 on macOS 15'
-            runs_on: macos-15
+        runtime:
+          - runs_on: macos-15
             xcode_version: '16.4'
             xcode_name: 'Xcode_16.4.app'
             ios_version: '18.5'
             device: 'iPhone 16 Pro'
-          - name: 'SwiftPM SPI Interfaces / Xcode 26.3 on macOS 26'
-            runs_on: macos-26
+          - runs_on: macos-26
             xcode_version: '26.3'
             xcode_name: 'Xcode_26.3.app'
             ios_version: '26.2'
@@ -50,6 +49,6 @@ jobs:
       - name: Run package tests
         uses: ./.github/actions/package
         with:
-          xcode-version: ${{ matrix.config.xcode_version }}
-          xcode-name: ${{ matrix.config.xcode_name }}
-          destination: 'platform=iOS Simulator,name=${{ matrix.config.device }},OS=${{ matrix.config.ios_version }}'
+          xcode-version: ${{ matrix.runtime.xcode_version }}
+          xcode-name: ${{ matrix.runtime.xcode_name }}
+          destination: 'platform=iOS Simulator,name=${{ matrix.runtime.device }},OS=${{ matrix.runtime.ios_version }}'

--- a/.github/workflows/package_interface.yml
+++ b/.github/workflows/package_interface.yml
@@ -1,4 +1,4 @@
-name: Package Tests
+name: Package Interface Tests
 
 on:
   push:
@@ -6,35 +6,39 @@ on:
     paths:
       - 'Sources/**'
       - 'Tests/**'
+      - 'Interfaces/**'
       - 'Package.swift'
       - '.github/actions/example/action.yml'
       - '.github/actions/package/action.yml'
-      - '.github/workflows/package.yml'
+      - '.github/workflows/package_interface.yml'
   pull_request:
     branches: [ main ]
     paths:
       - 'Sources/**'
       - 'Tests/**'
+      - 'Interfaces/**'
       - 'Package.swift'
       - '.github/actions/example/action.yml'
       - '.github/actions/package/action.yml'
-      - '.github/workflows/package.yml'
+      - '.github/workflows/package_interface.yml'
 
 jobs:
   test:
     name: ${{ matrix.config.name }}
     runs-on: ${{ matrix.config.runs_on }}
+    env:
+      SCREENSHIELDKIT_USE_SPI_INTERFACES: '1'
     strategy:
       fail-fast: false
       matrix:
         config:
-          - name: 'SwiftPM / Xcode 16.4 on macOS 15'
+          - name: 'SwiftPM SPI Interfaces / Xcode 16.4 on macOS 15'
             runs_on: macos-15
             xcode_version: '16.4'
             xcode_name: 'Xcode_16.4.app'
             ios_version: '18.5'
             device: 'iPhone 16 Pro'
-          - name: 'SwiftPM / Xcode 26.3 on macOS 26'
+          - name: 'SwiftPM SPI Interfaces / Xcode 26.3 on macOS 26'
             runs_on: macos-26
             xcode_version: '26.3'
             xcode_name: 'Xcode_26.3.app'

--- a/Example/Project.swift
+++ b/Example/Project.swift
@@ -1,11 +1,16 @@
+import Foundation
 import ProjectDescription
 
 let bundleIdPrefix = "top.kyleye.screenshieldkit"
 
+let packageDirectory = URL(fileURLWithPath: #filePath).deletingLastPathComponent().deletingLastPathComponent().path
+let spiInterfaceSettings: SettingsDictionary = [
+    "OTHER_SWIFT_FLAGS": "$(inherited) -I \(packageDirectory)/Interfaces",
+]
 let baseSettings: SettingsDictionary = [
     "CODE_SIGN_STYLE": "Automatic",
     "DEVELOPMENT_TEAM": "VB7MJ8R223",
-]
+].merging(spiInterfaceSettings)
 
 let lookInsideServerDependencies: [TargetDependency] = [
     .external(name: "LookInsideServer", condition: .when([.ios, .macos])),

--- a/Interfaces/OpenSwiftUI_SPI.swiftinterface
+++ b/Interfaces/OpenSwiftUI_SPI.swiftinterface
@@ -1,0 +1,12 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -enable-objc-interop -enable-library-evolution -swift-version 5 -module-name OpenSwiftUI_SPI -module-abi-name OpenSwiftUICore
+import Swift
+@_exported import OpenSwiftUI
+
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+extension OpenSwiftUICore.RedactionReasons {
+    public static var screencaptureProhibited: OpenSwiftUICore.RedactionReasons {
+        @_silgen_name("$s15OpenSwiftUICore16RedactionReasonsV23screencaptureProhibitedACvgZ")
+        get
+    }
+}

--- a/Interfaces/SwiftUI_SPI.swiftinterface
+++ b/Interfaces/SwiftUI_SPI.swiftinterface
@@ -1,0 +1,12 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -enable-objc-interop -enable-library-evolution -swift-version 5 -module-name SwiftUI_SPI -module-abi-name SwiftUI
+import Swift
+@_exported import SwiftUI
+
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+extension SwiftUI.RedactionReasons {
+    public static var screencaptureProhibited: SwiftUI.RedactionReasons {
+        @_silgen_name("$s7SwiftUI16RedactionReasonsV23screencaptureProhibitedACvgZ")
+        get
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,20 @@
 // swift-tools-version: 6.1
 
+import Foundation
 import PackageDescription
+
+let useSPIInterfaces = Context.environment["SCREENSHIELDKIT_USE_SPI_INTERFACES"].map {
+    let enabled = $0 == "1"
+    print("SCREENSHIELDKIT_USE_SPI_INTERFACES=\($0) -> \(enabled)")
+    return enabled
+} ?? false
+let packageDirectory = URL(fileURLWithPath: #filePath).deletingLastPathComponent().path
+let spiInterfaceSettings: [SwiftSetting] = useSPIInterfaces ? [
+    .unsafeFlags([
+        "-I", "\(packageDirectory)/Interfaces",
+        "-D", "SCREENSHIELDKIT_USE_SPI_INTERFACES",
+    ]),
+] : []
 
 let package = Package(
     name: "ScreenShieldKit",
@@ -35,7 +49,8 @@ let package = Package(
                     package: "OpenSwiftUI-spm",
                     condition: .when(traits: ["OpenSwiftUI"])
                 ),
-            ]
+            ],
+            swiftSettings: spiInterfaceSettings
         ),
         .testTarget(
             name: "ScreenShieldKitTests",
@@ -46,7 +61,8 @@ let package = Package(
                     package: "OpenSwiftUI-spm",
                     condition: .when(traits: ["OpenSwiftUI"])
                 ),
-            ]
+            ],
+            swiftSettings: spiInterfaceSettings
         ),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A Swift framework to hide UIView/NSView/CALayer, and SwiftUI views on iOS 18 and
 | **Coverage** | **Workflow** | **Matrix** | **Status** |
 |-|-|-|:-|
 | Package public API | [`package.yml`](.github/workflows/package.yml) | iOS 18.5 with Xcode 16.4 & iOS 26.2 with Xcode 26.3 | [![Package Tests](https://github.com/Kyle-Ye/ScreenShieldKit/actions/workflows/package.yml/badge.svg)](https://github.com/Kyle-Ye/ScreenShieldKit/actions/workflows/package.yml) |
+| Package public API with SPI interfaces | [`package_interface.yml`](.github/workflows/package_interface.yml) | iOS 18.5 with Xcode 16.4 & iOS 26.2 with Xcode 26.3 | [![Package Interface Tests](https://github.com/Kyle-Ye/ScreenShieldKit/actions/workflows/package_interface.yml/badge.svg)](https://github.com/Kyle-Ye/ScreenShieldKit/actions/workflows/package_interface.yml) |
 | UIKit example UI tests | [`example_uikit.yml`](.github/workflows/example_uikit.yml) | iOS 18.5 with Xcode 16.4 & iOS 26.2 with Xcode 26.3 | [![UIKit Example Tests](https://github.com/Kyle-Ye/ScreenShieldKit/actions/workflows/example_uikit.yml/badge.svg)](https://github.com/Kyle-Ye/ScreenShieldKit/actions/workflows/example_uikit.yml) |
 | SwiftUI example UI tests | [`example_swiftui.yml`](.github/workflows/example_swiftui.yml) | iOS 18.5 with Xcode 16.4 & iOS 26.2 with Xcode 26.3 | [![SwiftUI Example Tests](https://github.com/Kyle-Ye/ScreenShieldKit/actions/workflows/example_swiftui.yml/badge.svg)](https://github.com/Kyle-Ye/ScreenShieldKit/actions/workflows/example_swiftui.yml) |
 | OpenSwiftUI example UI tests | [`example_openswiftui.yml`](.github/workflows/example_openswiftui.yml) | iOS 18.5 with Xcode 16.4 & iOS 26.2 with Xcode 26.3 | [![OpenSwiftUI Example Tests](https://github.com/Kyle-Ye/ScreenShieldKit/actions/workflows/example_openswiftui.yml/badge.svg)](https://github.com/Kyle-Ye/ScreenShieldKit/actions/workflows/example_openswiftui.yml) |
@@ -40,6 +41,8 @@ Instead of wrapping your view in a secure UITextField or [ScreenShieldView](http
 
 you can just directly call the `hiddenFromCapture(_:)` API on your view or layer.
 
+### UIKit
+
 ```swift
 import ScreenShieldKit
 
@@ -50,6 +53,8 @@ view.hiddenFromCapture(true)
 view.hiddenFromCapture(false)
 ```
 
+### SwiftUI
+
 For SwiftUI on iOS 18, macOS 15, tvOS 18, watchOS 11, and visionOS 2 or newer:
 
 ```swift
@@ -59,6 +64,8 @@ import SwiftUI
 Text("Sensitive content")
     .hiddenFromCapture()
 ```
+
+### OpenSwiftUI
 
 For OpenSwiftUI, enable the package trait. The dependency uses the
 OpenSwiftUI-spm binary package from version 0.18.1.
@@ -75,9 +82,21 @@ Text("Sensitive content")
     .hiddenFromCapture()
 ```
 
+### AppKit
+
 AppKit support is best-effort. The current implementation uses the same private
 layer update mask path as UIKit, but that has been observed not to hide `NSView`
 contents from macOS system captures reliably.
+
+## SPI Interfaces
+
+To build against the local SPI interface shims instead of ScreenShieldKit's
+fallback declarations, set `SCREENSHIELDKIT_USE_SPI_INTERFACES=1` before
+building.
+
+```sh
+SCREENSHIELDKIT_USE_SPI_INTERFACES=1 swift build
+```
 
 ## Examples
 

--- a/Sources/ScreenShieldKit/OpenSwiftUI+ScreenShieldKit.swift
+++ b/Sources/ScreenShieldKit/OpenSwiftUI+ScreenShieldKit.swift
@@ -6,6 +6,10 @@
 //  SPDX-License-Identifier: MIT
 
 #if OpenSwiftUI && canImport(OpenSwiftUI)
+
+#if SCREENSHIELDKIT_USE_SPI_INTERFACES
+import OpenSwiftUI_SPI
+#else
 import OpenSwiftUI
 
 @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
@@ -13,6 +17,7 @@ extension RedactionReasons {
     @_spi(Private)
     public static let screencaptureProhibited: RedactionReasons = .init(rawValue: 1 << 3)
 }
+#endif
 
 @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 private struct ScreenCaptureRedactionModifier: ViewModifier {

--- a/Sources/ScreenShieldKit/SwiftUI+ScreenShieldKit.swift
+++ b/Sources/ScreenShieldKit/SwiftUI+ScreenShieldKit.swift
@@ -6,6 +6,10 @@
 //  SPDX-License-Identifier: MIT
 
 #if canImport(SwiftUI)
+
+#if SCREENSHIELDKIT_USE_SPI_INTERFACES
+import SwiftUI_SPI
+#else
 import SwiftUI
 
 @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
@@ -13,6 +17,7 @@ extension RedactionReasons {
     @_spi(Private)
     public static let screencaptureProhibited: RedactionReasons = .init(rawValue: 1 << 3)
 }
+#endif
 
 @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 private struct ScreenCaptureRedactionModifier: ViewModifier {


### PR DESCRIPTION
## Agent Summary

This PR adds an opt-in SPI interface build path for ScreenShieldKit and CI coverage for that configuration.

Changes:
- Adds local SwiftUI and OpenSwiftUI SPI interface shims and an environment-gated SwiftPM setting via `SCREENSHIELDKIT_USE_SPI_INTERFACES`.
- Adds package public API coverage and splits package CI into a shared package action plus a dedicated SPI interface workflow.
- Documents the SPI interface workflow and the environment variable in the README.

Validation:
- `swift build`
- `SCREENSHIELDKIT_USE_SPI_INTERFACES=1 swift build --traits OpenSwiftUI`